### PR TITLE
Eliminate *Hello* message before PUT

### DIFF
--- a/sck_beta_v0_9/SCKBase.cpp
+++ b/sck_beta_v0_9/SCKBase.cpp
@@ -553,6 +553,7 @@ boolean SCKBase::connect()
     if (readData(EE_ADDR_NUMBER_NETS, INTERNAL)<1) return false;
     if(enterCommandMode())
     {    
+      sendCommand(F("set comm remote 0")); // FFR Hide Hello message
       sendCommand(F("set wlan join 1")); // Disable AP mode
       sendCommand(F("set ip dhcp 1")); // Enable DHCP server
       sendCommand(F("set ip proto 10")); //TCP mode and HTML mode


### PR DESCRIPTION
From datasheet
2.3.12 set comm remote 
This command sets the ASCII string that is sent to the remote TCP client when the TCP 
port is opened, where is one or more characters up to a maximum of 32 (32 
bytes). If you do not wish to use a string, use a zero (0) as the parameter.
Default: HELLO
Example: set comm remote welcome // Set the string to welcome
